### PR TITLE
Update module name to match forked repo url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/goccy/go-zetasqlite
+module github.com/Recidiviz/go-zetasqlite
 
 go 1.17
 


### PR DESCRIPTION
Without this, trying to use this updated module in the bigquery emulator package fails.