### PR TITLE
Output correct date/time formats when casting to strings

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -382,13 +382,14 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		switch v.(type) {
 		// If this is coming from a date/time, the format is slightly different
 		// than when just writing the value out as a string.
-		// TODO(colindadams): Are the formats different between these?
-		case DateValue, DatetimeValue, TimeValue, TimestampValue:
-			valueTime, err := v.ToTime()
-			if err != nil {
-				return nil, err
-			}
-			return StringValue(valueTime.Format("2006-01-02 15:04:05.999999")), nil
+		case DateValue:
+			return convertTimeValueToStringWithFormat(v, "2006-01-02")
+		case DatetimeValue:
+			return convertTimeValueToStringWithFormat(v, "2006-01-02 15:04:05.999999")
+		case TimeValue:
+			return convertTimeValueToStringWithFormat(v, "15:04:05.999999")
+		case TimestampValue:
+			return convertTimeValueToStringWithFormat(v, "2006-01-02 15:04:05.999999-07")
 		}
 		s, err := v.ToString()
 		if err != nil {
@@ -522,6 +523,14 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		return v, nil
 	}
 	return nil, fmt.Errorf("unsupported cast %s value", t.Kind())
+}
+
+func convertTimeValueToStringWithFormat(v Value, format string) (Value, error) {
+	valueTime, err := v.ToTime()
+	if err != nil {
+		return nil, err
+	}
+	return StringValue(valueTime.UTC().Format(format)), nil
 }
 
 func ValueFromGoValue(v interface{}) (Value, error) {

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -378,7 +378,24 @@ func CastValue(t types.Type, v Value) (Value, error) {
 			return nil, err
 		}
 		return FloatValue(f64), nil
-	case types.STRING, types.ENUM:
+	case types.STRING:
+		switch v.(type) {
+		// If this is coming from a date/time, the format is slightly different
+		// than when just writing the value out as a string.
+		// TODO(colindadams): Are the formats different between these?
+		case DateValue, DatetimeValue, TimeValue, TimestampValue:
+			valueTime, err := v.ToTime()
+			if err != nil {
+				return nil, err
+			}
+			return StringValue(valueTime.Format("2006-01-02 15:04:05.999999")), nil
+		}
+		s, err := v.ToString()
+		if err != nil {
+			return nil, err
+		}
+		return StringValue(s), nil
+	case types.ENUM:
 		s, err := v.ToString()
 		if err != nil {
 			return nil, err

--- a/internal/function_datetime.go
+++ b/internal/function_datetime.go
@@ -100,7 +100,7 @@ func DATETIME(args ...Value) (Value, error) {
 			}
 			return DatetimeValue(t.In(loc)), nil
 		}
-		return DatetimeValue(t), nil
+		return DatetimeValue(t.UTC()), nil
 	}
 	return nil, fmt.Errorf("DATETIME: first argument must be DATE or TIMESTAMP type")
 }

--- a/internal/function_time.go
+++ b/internal/function_time.go
@@ -57,13 +57,13 @@ func TIME(args ...Value) (Value, error) {
 			}
 			return TimeValue(t.In(loc)), nil
 		}
-		return TimeValue(t), nil
+		return TimeValue(t.UTC()), nil
 	case DatetimeValue:
 		t, err := args[0].ToTime()
 		if err != nil {
 			return nil, err
 		}
-		return TimeValue(t), nil
+		return TimeValue(t.UTC()), nil
 	}
 	return nil, fmt.Errorf("TIME: invalid first argument type %T", args[0])
 }

--- a/internal/value.go
+++ b/internal/value.go
@@ -1627,7 +1627,6 @@ func (d DateValue) Interface() interface{} {
 }
 
 const (
-	// TODO(colincadams): no T
 	datetimeFormat = "2006-01-02T15:04:05.999999"
 )
 
@@ -2009,7 +2008,6 @@ func (t TimestampValue) ToInt64() (int64, error) {
 }
 
 func (t TimestampValue) ToString() (string, error) {
-	// TODO(colincadams): no T
 	return time.Time(t).Format(time.RFC3339Nano), nil
 }
 

--- a/internal/value.go
+++ b/internal/value.go
@@ -1627,6 +1627,7 @@ func (d DateValue) Interface() interface{} {
 }
 
 const (
+	// TODO(colincadams): no T
 	datetimeFormat = "2006-01-02T15:04:05.999999"
 )
 
@@ -2008,6 +2009,7 @@ func (t TimestampValue) ToInt64() (int64, error) {
 }
 
 func (t TimestampValue) ToString() (string, error) {
+	// TODO(colincadams): no T
 	return time.Time(t).Format(time.RFC3339Nano), nil
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -3607,6 +3607,12 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		},
 
 		{
+			name:         "cast date as string",
+			query:        `SELECT CAST(DATE("2022-08-01 06:47:51.123456-07:00") AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01"}},
+		},
+
+		{
 			name:         "last_day",
 			query:        `SELECT LAST_DAY(DATE '2008-11-25') AS last_day`,
 			expectedRows: [][]interface{}{{"2008-11-30"}},
@@ -3767,29 +3773,14 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008"}},
 		},
 		{
-			name:         "cast date as string",
-			query:        `SELECT CAST(DATE("2022-08-01") AS STRING)`,
-			expectedRows: [][]interface{}{{"2022-08-01"}},
-		},
-		{
 			name:         "cast datetime as string",
-			query:        `SELECT CAST(DATETIME("2022-08-01") AS STRING)`,
-			expectedRows: [][]interface{}{{"2022-08-01 00:00:00"}},
+			query:        `SELECT CAST(DATETIME(TIMESTAMP("2022-08-01 06:47:51.123456-07:00")) AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456"}},
 		},
 		{
 			name:         "cast date as datetime",
 			query:        `SELECT CAST(DATE("1987-01-25") AS DATETIME)`,
 			expectedRows: [][]interface{}{{"1987-01-25T00:00:00"}},
-		},
-		{
-			name:         "cast time as string",
-			query:        `SELECT CAST(TIME("1987-01-25 14:57:08") AS STRING)`,
-			expectedRows: [][]interface{}{{"14:57:08"}},
-		},
-		{
-			name:         "cast time as string",
-			query:        `SELECT CAST(TIMESTAMP("2022-08-01 13:47:51") AS STRING)`,
-			expectedRows: [][]interface{}{{"2022-08-01 13:47:51+00"}},
 		},
 		{
 			name:         "parse datetime",
@@ -3866,6 +3857,21 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "format_time with %E*S",
 			query:        `SELECT FORMAT_TIME("%E*S", TIME "15:30:12.345678")`,
 			expectedRows: [][]interface{}{{"12.345678"}},
+		},
+		{
+			name:         "cast time as string",
+			query:        `SELECT CAST(TIME("2022-08-01 06:47:51.123456-04:00") AS STRING)`,
+			expectedRows: [][]interface{}{{"10:47:51.123456"}},
+		},
+		{
+			name:         "cast time with timezone as string",
+			query:        `SELECT CAST(TIME("2022-08-01 06:47:51.123456-04:00", "America/Los_Angeles") AS STRING)`,
+			expectedRows: [][]interface{}{{"03:47:51.123456"}},
+		},
+		{
+			name:         "cast time from datetime as string",
+			query:        `SELECT CAST(TIME(DATETIME(TIMESTAMP("2022-08-01 06:47:51.123456-04:00"))) AS STRING)`,
+			expectedRows: [][]interface{}{{"10:47:51.123456"}},
 		},
 		{
 			name:         "parse time with %I:%M:%S",
@@ -4008,6 +4014,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "format_timestamp with %Ez",
 			query:        `SELECT FORMAT_TIMESTAMP("%Ez", TIMESTAMP "2008-12-25 15:30:12.345678+00")`,
 			expectedRows: [][]interface{}{{"+00:00"}},
+		},
+		{
+			name:         "cast timestamp as string",
+			query:        `SELECT CAST(TIMESTAMP("2022-08-01 06:47:51.123456-07:00") AS STRING);`,
+			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456+00"}},
 		},
 		{
 			name:         "parse timestamp with %a %b %e %I:%M:%S %Y",

--- a/query_test.go
+++ b/query_test.go
@@ -3767,6 +3767,46 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008"}},
 		},
 		{
+			name:         "cast datetime as string 1",
+			query:        `SELECT SAFE.PARSE_DATE('%m/%d/%Y', "01/25/1987")`,
+			expectedRows: [][]interface{}{{"1987-01-25"}},
+		},
+		{
+			name:         "cast datetime as string 2",
+			query:        `SELECT SAFE_CAST(SAFE.PARSE_DATE('%m/%d/%Y', "01/25/1987") AS DATETIME)`,
+			expectedRows: [][]interface{}{{"1987-01-25T00:00:00"}},
+		},
+		{
+			name:         "cast datetime as string 3", // fail
+			query:        `SELECT CAST(SAFE_CAST(SAFE.PARSE_DATE('%m/%d/%Y', "01/25/1987") AS DATETIME) AS STRING)`,
+			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+		},
+		{
+			name:         "cast datetime as string 4", // fail
+			query:        `SELECT CAST(SAFE_CAST(DATE(1987, 1, 25) AS DATETIME) AS STRING)`,
+			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+		},
+		{
+			name:         "cast datetime as string 5", // fail
+			query:        `SELECT CAST(DATETIME(1987, 1, 25, 0, 0, 0) AS STRING)`,
+			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+		},
+		{
+			name:         "cast datetime as string 6",
+			query:        `SELECT DATETIME(1987, 1, 25, 0, 0, 0)`,
+			expectedRows: [][]interface{}{{"1987-01-25T00:00:00"}},
+		},
+		{
+			name:         "cast datetime as string 7", // fail
+			query:        `SELECT CAST(DATETIME(1987, 1, 25, 0, 0, 0) AS STRING FORMAT 'YYYY-MM-DD HH:MM:SS')`,
+			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+		},
+		{
+			name:         "new test", // fail
+			query:        `SELECT PARSE_DATE('%m/%d/%y', '5/20/2000')`,
+			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+		},
+		{
 			name:         "parse datetime",
 			query:        `SELECT PARSE_DATETIME("%a %b %e %I:%M:%S %Y", "Thu Dec 25 07:30:00 2008")`,
 			expectedRows: [][]interface{}{{"2008-12-25T07:30:00"}},

--- a/query_test.go
+++ b/query_test.go
@@ -3767,44 +3767,29 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008"}},
 		},
 		{
-			name:         "cast datetime as string 1",
-			query:        `SELECT SAFE.PARSE_DATE('%m/%d/%Y', "01/25/1987")`,
-			expectedRows: [][]interface{}{{"1987-01-25"}},
+			name:         "cast date as string",
+			query:        `SELECT CAST(DATE("2022-08-01") AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01"}},
 		},
 		{
-			name:         "cast datetime as string 2",
-			query:        `SELECT SAFE_CAST(SAFE.PARSE_DATE('%m/%d/%Y', "01/25/1987") AS DATETIME)`,
+			name:         "cast datetime as string",
+			query:        `SELECT CAST(DATETIME("2022-08-01") AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01 00:00:00"}},
+		},
+		{
+			name:         "cast date as datetime",
+			query:        `SELECT CAST(DATE("1987-01-25") AS DATETIME)`,
 			expectedRows: [][]interface{}{{"1987-01-25T00:00:00"}},
 		},
 		{
-			name:         "cast datetime as string 3", // fail
-			query:        `SELECT CAST(SAFE_CAST(SAFE.PARSE_DATE('%m/%d/%Y', "01/25/1987") AS DATETIME) AS STRING)`,
-			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+			name:         "cast time as string",
+			query:        `SELECT CAST(TIME("1987-01-25 14:57:08") AS STRING)`,
+			expectedRows: [][]interface{}{{"14:57:08"}},
 		},
 		{
-			name:         "cast datetime as string 4", // fail
-			query:        `SELECT CAST(SAFE_CAST(DATE(1987, 1, 25) AS DATETIME) AS STRING)`,
-			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
-		},
-		{
-			name:         "cast datetime as string 5", // fail
-			query:        `SELECT CAST(DATETIME(1987, 1, 25, 0, 0, 0) AS STRING)`,
-			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
-		},
-		{
-			name:         "cast datetime as string 6",
-			query:        `SELECT DATETIME(1987, 1, 25, 0, 0, 0)`,
-			expectedRows: [][]interface{}{{"1987-01-25T00:00:00"}},
-		},
-		{
-			name:         "cast datetime as string 7", // fail
-			query:        `SELECT CAST(DATETIME(1987, 1, 25, 0, 0, 0) AS STRING FORMAT 'YYYY-MM-DD HH:MM:SS')`,
-			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
-		},
-		{
-			name:         "new test", // fail
-			query:        `SELECT PARSE_DATE('%m/%d/%y', '5/20/2000')`,
-			expectedRows: [][]interface{}{{"1987-01-25 00:00:00"}},
+			name:         "cast time as string",
+			query:        `SELECT CAST(TIMESTAMP("2022-08-01 13:47:51") AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01 13:47:51+00"}},
 		},
 		{
 			name:         "parse datetime",


### PR DESCRIPTION
## Description of the change

When casting date and time types to strings, the emulator was using the same format as when the values are displayed, however BigQuery uses different formats in these cases. This updates the functionality to match test cases based on running queries in BigQuery.

Note: This does not yet support format clauses when casting to strings. That is lower priority for our use case.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Recidiviz/recidiviz-data#20960

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
