### PR TITLE
[Timestamp] Use microsecond precision to support full range of BigQuery timestamps

### DIFF
--- a/internal/decoder.go
+++ b/internal/decoder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"time"
 
 	"github.com/goccy/go-json"
 )
@@ -73,11 +74,14 @@ func decodeFromValueLayout(layout *ValueLayout) (Value, error) {
 		}
 		return TimeValue(t), nil
 	case TimestampValueType:
-		unixnano, err := strconv.ParseInt(layout.Body, 10, 64)
+		microsec, err := strconv.ParseInt(layout.Body, 10, 64)
+		microSecondsInSecond := int64(time.Second) / int64(time.Microsecond)
+		sec := microsec / microSecondsInSecond
+		remainder := microsec - (sec * microSecondsInSecond)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse unixnano for timestamp value %s: %w", layout.Body, err)
+			return nil, fmt.Errorf("failed to parse unixmicro for timestamp value %s: %w", layout.Body, err)
 		}
-		return TimestampValue(timeFromUnixNano(unixnano)), nil
+		return TimestampValue(time.Unix(sec, remainder*int64(time.Microsecond))), nil
 	case IntervalValueType:
 		return parseInterval(layout.Body)
 	case JsonValueType:

--- a/query_test.go
+++ b/query_test.go
@@ -3982,6 +3982,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			},
 		},
 		{
+			name:  "minimum / maximum timestamp value uses microsecond precision and range",
+			query: `SELECT TIMESTAMP '0001-01-01 00:00:00.000000+00', TIMESTAMP '9999-12-31 23:59:59.999999+00'`,
+			expectedRows: [][]interface{}{
+				{
+					createTimestampFormatFromTime(time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)),
+					createTimestampFormatFromTime(time.Date(9999, 12, 31, 23, 59, 59, 999999000, time.UTC)),
+				},
+			},
+		},
+		{
 			name:         "string",
 			query:        `SELECT STRING(TIMESTAMP "2008-12-25 15:30:00+00", "UTC")`,
 			expectedRows: [][]interface{}{{"2008-12-25 15:30:00+00"}},


### PR DESCRIPTION
We were previously encoding / decoding timestamp values using nanoseconds, which only covers a partial range of the supported timestamps as we hit the lowest / highest allowed int64 values more quickly. 

Since BigQuery only supports microsecond precision, this switches us to it.

Closes Recidiviz/recidiviz-data#21149