### PR TITLE
[Date] Base date used when parsing is start of unix time, not 0001-01-01

### DIFF
--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -1083,7 +1083,10 @@ func parseTimeFormat(formatStr, targetStr string, typ TimeFormatType) (*time.Tim
 		targetIdx int
 		formatIdx int
 	)
-	ret := &time.Time{}
+	epoch := time.Unix(0, 0)
+	var ret *time.Time
+	ret = &epoch
+
 	for formatIdx < len(format) {
 		c := format[formatIdx]
 		if c == '%' {

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -1084,8 +1084,7 @@ func parseTimeFormat(formatStr, targetStr string, typ TimeFormatType) (*time.Tim
 		formatIdx int
 	)
 	epoch := time.Unix(0, 0)
-	var ret *time.Time
-	ret = &epoch
+	var ret = &epoch
 
 	for formatIdx < len(format) {
 		c := format[formatIdx]

--- a/query_test.go
+++ b/query_test.go
@@ -3639,6 +3639,12 @@ WITH example AS (
 			},
 		},
 		{
+			name:  "base date is epoch",
+			query: `SELECT PARSE_DATE("%m", "03")`,
+			expectedRows: [][]interface{}{
+				{"1970-03-01"},
+			}},
+		{
 			name: "extract date",
 			query: `
 SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH FROM date),


### PR DESCRIPTION
goccy/go-zetasqlite#136