### PR TITLE
[Aggregate] Properly return `nil` for `STRING_AGG` when called with `null` or 0-length array

### DIFF
--- a/internal/function_aggregate.go
+++ b/internal/function_aggregate.go
@@ -488,12 +488,18 @@ func (f *STRING_AGG) Done() (Value, error) {
 		f.values = f.values[:minLen]
 	}
 	values := make([]string, 0, len(f.values))
+
+	foundNotNilValue := false
 	for _, v := range f.values {
 		text, err := v.Value.ToString()
 		if err != nil {
 			return nil, err
 		}
+		foundNotNilValue = true
 		values = append(values, text)
+	}
+	if !foundNotNilValue {
+		return nil, nil
 	}
 	return StringValue(strings.Join(values, f.delim)), nil
 }

--- a/query_test.go
+++ b/query_test.go
@@ -824,6 +824,16 @@ SELECT ARRAY_CONCAT_AGG(x) AS array_concat_agg FROM (
 			expectedRows: [][]interface{}{{"apple,pear,banana,pear"}},
 		},
 		{
+			name:         "string_agg with length 0",
+			query:        `SELECT STRING_AGG(fruit) FROM UNNEST(ARRAY<STRING>[]) fruit;`,
+			expectedRows: [][]interface{}{{nil}},
+		},
+		{
+			name:         "string_agg with null",
+			query:        `SELECT STRING_AGG(null) FROM UNNEST(ARRAY<STRING>[]);`,
+			expectedRows: [][]interface{}{{nil}},
+		},
+		{
 			name:         "string_agg with delimiter",
 			query:        `SELECT STRING_AGG(fruit, " & ") AS string_agg FROM UNNEST(["apple", "pear", "banana", "pear"]) AS fruit`,
 			expectedRows: [][]interface{}{{"apple & pear & banana & pear"}},


### PR DESCRIPTION
Previously we were returning empty string.

goccy/go-zetasqlite#146