### PR TITLE
[String] `LIKE` properly escapes regexp-characters

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/goccy/go-json"

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/goccy/go-json"

--- a/internal/function.go
+++ b/internal/function.go
@@ -214,7 +214,7 @@ func LIKE(a, b Value) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	wildcard := strings.Replace(vb, "%", ".*", -1)
+	wildcard := strings.Replace(regexp.QuoteMeta(vb), "%", ".*", -1)
 	matchLimits := fmt.Sprintf("^%s$", wildcard)
 	re, err := regexp.Compile(matchLimits)
 	if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -159,6 +159,11 @@ func TestQuery(t *testing.T) {
 			expectedRows: [][]interface{}{{true}},
 		},
 		{
+			name:         "like operator - special regex characters",
+			query:        `SELECT 'my*string' LIKE '%%*%%', 'my*string' LIKE '%%([][%';`,
+			expectedRows: [][]interface{}{{true, false}},
+		},
+		{
 			name:         "like operator2",
 			query:        `SELECT "abcd" LIKE "%a%"`,
 			expectedRows: [][]interface{}{{true}},


### PR DESCRIPTION
goccy/go-zetasqlite#149