### PR TITLE
[String] Cast to INT64 should use base-10 parsing

### DIFF
--- a/internal/value.go
+++ b/internal/value.go
@@ -245,9 +245,9 @@ func (sv StringValue) ToInt64() (int64, error) {
 		return 0, nil
 	}
 	toParse := string(sv)
-	base := 0
-	if !strings.Contains(strings.ToLower(toParse), "0x") {
-		base = 10
+	base := 10
+	if strings.Contains(strings.ToLower(toParse), "0x") {
+		base = 0
 	}
 	return strconv.ParseInt(toParse, base, 64)
 }

--- a/internal/value.go
+++ b/internal/value.go
@@ -244,7 +244,7 @@ func (sv StringValue) ToInt64() (int64, error) {
 	if sv == "" {
 		return 0, nil
 	}
-	return strconv.ParseInt(string(sv), 0, 64)
+	return strconv.ParseInt(string(sv), 10, 64)
 }
 
 func (sv StringValue) ToString() (string, error) {

--- a/internal/value.go
+++ b/internal/value.go
@@ -244,7 +244,12 @@ func (sv StringValue) ToInt64() (int64, error) {
 	if sv == "" {
 		return 0, nil
 	}
-	return strconv.ParseInt(string(sv), 10, 64)
+	toParse := string(sv)
+	base := 0
+	if !strings.Contains(strings.ToLower(toParse), "0x") {
+		base = 10
+	}
+	return strconv.ParseInt(toParse, base, 64)
 }
 
 func (sv StringValue) ToString() (string, error) {

--- a/query_test.go
+++ b/query_test.go
@@ -2818,6 +2818,18 @@ SELECT item FROM Produce WHERE Produce.category = 'vegetable' QUALIFY RANK() OVE
 			query:        `SELECT CAST('0x87a' as INT64), CAST(CONCAT('0x', '87a') as INT64), CAST(SUBSTR('q0x87a', 2) as INT64), CAST(s AS INT64) FROM (SELECT CONCAT('0x', '87a') AS s)`,
 			expectedRows: [][]interface{}{{int64(2170), int64(2170), int64(2170), int64(2170)}},
 		},
+		{
+			name: "cast string to int64 - leading zeroes",
+			query: `WITH toks AS (
+				SELECT "000800" AS x
+				UNION ALL SELECT "-0900"
+				UNION ALL SELECT "+000100"
+				UNION ALL SELECT "0"
+				UNION ALL SELECT "0000"
+			)
+			SELECT ARRAY_AGG(CAST(x AS INT64)) FROM toks`,
+			expectedRows: [][]interface{}{{[]any{int64(800), int64(-900), int64(100), int64(0), int64(0)}}},
+		},
 
 		// hash functions
 		{

--- a/query_test.go
+++ b/query_test.go
@@ -2819,7 +2819,7 @@ SELECT item FROM Produce WHERE Produce.category = 'vegetable' QUALIFY RANK() OVE
 			expectedRows: [][]interface{}{{int64(2170), int64(2170), int64(2170), int64(2170)}},
 		},
 		{
-			name: "cast string to int64 - leading zeroes",
+			name: "cast string to int64 - leading zeros",
 			query: `WITH toks AS (
 				SELECT "000800" AS x
 				UNION ALL SELECT "-0900"


### PR DESCRIPTION
Using base 0 leads to incorrectly parsed integers as well as errors depending on leading-zero format.

goccy/go-zetasqlite#158