### PR TITLE
[Windowing] [Formatter] Reset format context in-between analytic function groups

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -1043,6 +1043,7 @@ func (n *AnalyticScanNode) FormatSQL(ctx context.Context) (string, error) {
 	}
 	ctx = withAnalyticInputScan(ctx, formattedInput)
 	orderColumnNames := analyticOrderColumnNamesFromContext(ctx)
+	var scanOrderBy []*analyticOrderBy
 	for _, group := range n.node.FunctionGroupList() {
 		if group.PartitionBy() != nil {
 			var partitionColumns []string
@@ -1052,10 +1053,12 @@ func (n *AnalyticScanNode) FormatSQL(ctx context.Context) (string, error) {
 					partitionColumns,
 					colName,
 				)
-				orderColumnNames.values = append(orderColumnNames.values, &analyticOrderBy{
+				order := &analyticOrderBy{
 					column: colName,
 					isAsc:  true,
-				})
+				}
+				orderColumnNames.values = append(orderColumnNames.values, order)
+				scanOrderBy = append(scanOrderBy, order)
 			}
 			ctx = withAnalyticPartitionColumnNames(ctx, partitionColumns)
 		}
@@ -1063,15 +1066,21 @@ func (n *AnalyticScanNode) FormatSQL(ctx context.Context) (string, error) {
 			for _, item := range group.OrderBy().OrderByItemList() {
 				colName := uniqueColumnName(ctx, item.ColumnRef().Column())
 				formattedColName := fmt.Sprintf("`%s`", colName)
-				orderColumnNames.values = append(orderColumnNames.values, &analyticOrderBy{
+				order := &analyticOrderBy{
 					column: formattedColName,
 					isAsc:  !item.IsDescending(),
-				})
+				}
+				orderColumnNames.values = append(orderColumnNames.values, order)
+				scanOrderBy = append(scanOrderBy, order)
 			}
 		}
 		if _, err := newNode(group).FormatSQL(ctx); err != nil {
 			return "", err
 		}
+
+		// Reset context after each analytic function group
+		orderColumnNames.values = []*analyticOrderBy{}
+		ctx = withAnalyticPartitionColumnNames(ctx, nil)
 	}
 	columns := []string{}
 	columnMap := columnRefMap(ctx)
@@ -1088,7 +1097,7 @@ func (n *AnalyticScanNode) FormatSQL(ctx context.Context) (string, error) {
 		}
 	}
 	var orderColumnFormattedNames []string
-	for _, col := range orderColumnNames.values {
+	for _, col := range scanOrderBy {
 		if col.isAsc {
 			orderColumnFormattedNames = append(
 				orderColumnFormattedNames,

--- a/query_test.go
+++ b/query_test.go
@@ -2063,6 +2063,28 @@ FROM finishers`,
 				{"Suzy Slane", createTimestampFormatFromString("2016-10-18 03:06:24+00"), "F35-39", "Desiree Berry"},
 			},
 		},
+		// Regression test for https://github.com/goccy/go-zetasqlite/issues/160
+		{
+			name: "window partitions are distinct from each other",
+			query: `
+WITH inventory AS (
+  SELECT 'banana' AS item, 'fruit' AS kind, 2 AS purchases
+  UNION ALL SELECT 'onion', 'vegetable', 3
+  UNION ALL SELECT 'orange', 'fruit', 4
+  ORDER BY item ASC
+)
+SELECT
+  item,
+  purchases,
+  LEAD(item) OVER (PARTITION BY kind ORDER BY item ASC) AS next_in_kind,
+  LAG(item) OVER (ORDER BY purchases ASC) AS next_best_seller
+FROM inventory`,
+			expectedRows: [][]interface{}{
+				{"banana", int64(2), "orange", nil},
+				{"orange", int64(4), nil, "onion"},
+				{"onion", int64(3), nil, "banana"},
+			},
+		},
 		{
 			name: "lag with option",
 			query: `


### PR DESCRIPTION
goccy/go-zetasqlite#160

Previously the partition by and order by clauses would be accumulated across window functions. This resets the context after each window function group has been processed.