### PR TITLE
Fix `IN()` operator return when left-hand side is null

### DIFF
--- a/internal/function.go
+++ b/internal/function.go
@@ -244,7 +244,7 @@ func BETWEEN(target, start, end Value) (Value, error) {
 
 func IN(a Value, values ...Value) (Value, error) {
 	if a == nil {
-		return BoolValue(false), nil
+		return nil, nil
 	}
 	for _, v := range values {
 		if v == nil {

--- a/query_test.go
+++ b/query_test.go
@@ -189,14 +189,16 @@ func TestQuery(t *testing.T) {
 			expectedRows: [][]interface{}{{true}},
 		},
 		{
-			name:         "in operator",
-			query:        `SELECT 3 IN (1, 2, 3, 4)`,
-			expectedRows: [][]interface{}{{true}},
+			name:  "in operator",
+			query: `SELECT 3 IN (1, 2, 3, 4), null IN (1), null IN (null)`,
+			// When left-hand side is null, null is always returned
+			expectedRows: [][]interface{}{{true, nil, nil}},
 		},
 		{
-			name:         "not in operator",
-			query:        `SELECT 5 NOT IN (1, 2, 3, 4)`,
-			expectedRows: [][]interface{}{{true}},
+			name:  "not in operator",
+			query: `SELECT 5 NOT IN (1, 2, 3, 4), null NOT IN (1), null NOT IN (null)`,
+			// When left-hand side is null, null is always returned
+			expectedRows: [][]interface{}{{true, nil, nil}},
 		},
 		{
 			name:         "is null operator",


### PR DESCRIPTION
goccy/go-zetasqlite#172