### PR TITLE
Use `WITHOUT ROWID` table clustering for primary keys

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -3,7 +3,6 @@ package zetasqlite_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -206,7 +205,7 @@ CREATE TABLE IF NOT EXISTS Singers (
 
 		_, err = stmt.Exec(int64(1), "Miss", "Kitten")
 		if !strings.HasSuffix(err.Error(), "UNIQUE constraint failed: Singers.SingerId") {
-			t.Fatal(fmt.Sprintf("expected failed unique constraint err, got: %s", err))
+			t.Fatalf("expected failed unique constraint err, got: %s", err)
 		}
 	})
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -3,6 +3,8 @@ package zetasqlite_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strings"
 	"testing"
 
 	zetasqlite "github.com/goccy/go-zetasqlite"
@@ -175,6 +177,36 @@ CREATE TABLE IF NOT EXISTS Singers (
 		}
 		if diff := cmp.Diff(rowsCatalog.Function.Deleted[0].NamePath, []string{"ANY_ADD"}); diff != "" {
 			t.Errorf("(-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestCreateTable(t *testing.T) {
+	t.Run("primary keys", func(t *testing.T) {
+		db, err := sql.Open("zetasqlite", ":memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`
+CREATE TABLE IF NOT EXISTS Singers (
+  SingerId   INT64 NOT NULL PRIMARY KEY,
+  FirstName  STRING(1024),
+  LastName   STRING(1024)
+)`); err != nil {
+			t.Fatal(err)
+		}
+		stmt, err := db.Prepare("INSERT Singers (SingerId, FirstName, LastName) VALUES (@SingerID, @FirstName, @LastName)")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = stmt.Exec(int64(1), "Kylie", "Minogue")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = stmt.Exec(int64(1), "Miss", "Kitten")
+		if !strings.HasSuffix(err.Error(), "UNIQUE constraint failed: Singers.SingerId") {
+			t.Fatal(fmt.Sprintf("expected failed unique constraint err, got: %s", err))
 		}
 	})
 }


### PR DESCRIPTION
This allows SQLite to do efficient row lookups when used in conjunction with #43 
https://www.sqlite.org/withoutrowid.html