### PR TITLE
Delegate comparison operators to SQLite when possible

### DIFF
--- a/internal/coordinator_extractor.go
+++ b/internal/coordinator_extractor.go
@@ -302,7 +302,7 @@ func (e *NodeExtractor) extractArgumentRefData(node *ast.ArgumentRefNode, ctx Tr
 // extractDMLDefaultData extracts data from DML default nodes
 func (e *NodeExtractor) extractDMLDefaultData(node *ast.DMLDefaultNode, ctx TransformContext) (ExpressionData, error) {
 	return ExpressionData{
-		Type: ExpressionTypeLiteral,
+		Type:    ExpressionTypeLiteral,
 		Literal: &LiteralData{
 			// DEFAULT keyword representation
 		},
@@ -797,6 +797,10 @@ func (e *NodeExtractor) extractWildcardTableAsSetOp(wildcardTable *WildcardTable
 				// Check if this column exists in the current table
 				var columnExpr ExpressionData
 				if wildcardTable.existsColumn(tableSpec, col.Name) {
+					t, err := col.Type.ToZetaSQLType()
+					if err != nil {
+						return ScanData{}, fmt.Errorf("failed to extract zetasqlite type: %w", err)
+					}
 					// Column exists - reference it directly
 					columnExpr = ExpressionData{
 						Type: ExpressionTypeColumn,
@@ -804,6 +808,7 @@ func (e *NodeExtractor) extractWildcardTableAsSetOp(wildcardTable *WildcardTable
 							ColumnID:   columnIdsByName[col.Name],
 							ColumnName: col.Name,
 							TableName:  tableSpec.TableName(),
+							Type:       t,
 						},
 					}
 				} else {

--- a/internal/transformer_function.go
+++ b/internal/transformer_function.go
@@ -206,6 +206,14 @@ func (t *FunctionCallTransformer) Transform(data ExpressionData, ctx TransformCo
 			}
 		}
 
+		// Fast path optimization: bypass function calls for primitive type comparisons
+		// Functions calls incur huge overheads: as each call's args must be decoded/encoded, as well as
+		// allocated within both the modernc.org/sqlite driver and the go-zetasqlite driver
+		// This could happen potentially hundreds of thousands of times per query in the case of complex JOINs
+		if canOptimizeComparison(function) {
+			return optimizeComparisonToSQL(function.Name, args)
+		}
+
 		funcMap := funcMapFromContext(ctx.Context())
 		if spec, exists := funcMap[function.Name]; exists {
 			return spec.CallSQL(ctx.Context(), function, args)
@@ -219,5 +227,76 @@ func (t *FunctionCallTransformer) Transform(data ExpressionData, ctx TransformCo
 				WindowSpec: windowSpec,
 			},
 		}, nil
+	}
+}
+
+// canOptimizeComparison checks if a comparison function can be optimized to use direct SQL operators
+func canOptimizeComparison(function *FunctionCallData) bool {
+	if len(function.Arguments) != 2 {
+		return false
+	}
+
+	_, found := comparisonToOperator[function.Name]
+	if found {
+		// Both arguments must be primitive SQLite-compatible types
+		return isPrimitiveSQLiteType(function.Arguments[0]) && isPrimitiveSQLiteType(function.Arguments[1])
+	}
+
+	return false
+}
+
+var comparisonToOperator = map[string]string{
+	"zetasqlite_equal":            "=",
+	"zetasqlite_not_equal":        "!=",
+	"zetasqlite_less":             "<",
+	"zetasqlite_greater":          ">",
+	"zetasqlite_less_or_equal":    "<=",
+	"zetasqlite_greater_or_equal": ">=",
+}
+
+// optimizeComparisonToSQL converts comparison functions to direct SQL operators
+func optimizeComparisonToSQL(functionName string, args []*SQLExpression) (*SQLExpression, error) {
+	if len(args) != 2 {
+		// Should not happen due to canOptimizeComparison check, but be safe
+		return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
+	}
+
+	operator, found := comparisonToOperator[functionName]
+	if !found {
+		return nil, fmt.Errorf("unknown comparison operator: %s", functionName)
+	}
+
+	return NewBinaryExpression(args[0], operator, args[1]), nil
+}
+
+// isPrimitiveSQLiteType checks if an expression represents a primitive type that SQLite can handle natively
+func isPrimitiveSQLiteType(expr ExpressionData) bool {
+	switch expr.Type {
+	case ExpressionTypeLiteral:
+		if expr.Literal == nil || expr.Literal.Value == nil {
+			return false
+		}
+		// Check if the literal value is a primitive type
+		switch expr.Literal.Value.(type) {
+		case IntValue, FloatValue, BoolValue:
+			return true
+		case StringValue:
+			// String literals can be compared directly in SQLite
+			return true
+		default:
+			return false
+		}
+	case ExpressionTypeColumn:
+		t := expr.Column.Type
+		return t.IsInt32() ||
+			t.IsInt64() ||
+			t.IsUint32() ||
+			t.IsUint64() ||
+			t.IsBool() ||
+			t.IsFloat() ||
+			t.IsDouble() ||
+			t.IsString()
+	default:
+		return false
 	}
 }

--- a/internal/transformer_function.go
+++ b/internal/transformer_function.go
@@ -206,12 +206,12 @@ func (t *FunctionCallTransformer) Transform(data ExpressionData, ctx TransformCo
 			}
 		}
 
-		// Fast path optimization: bypass function calls for primitive type comparisons
-		// Functions calls incur huge overheads: as each call's args must be decoded/encoded, as well as
+		// Fast path optimization: bypass function calls for primitive type operations
+		// Function calls incur huge overheads: as each call's args must be decoded/encoded, as well as
 		// allocated within both the modernc.org/sqlite driver and the go-zetasqlite driver
 		// This could happen potentially hundreds of thousands of times per query in the case of complex JOINs
-		if canOptimizeComparison(function) {
-			return optimizeComparisonToSQL(function.Name, args)
+		if canOptimizeFunction(function) {
+			return optimizeFunctionToSQL(function.Name, args)
 		}
 
 		funcMap := funcMapFromContext(ctx.Context())
@@ -230,46 +230,77 @@ func (t *FunctionCallTransformer) Transform(data ExpressionData, ctx TransformCo
 	}
 }
 
-// canOptimizeComparison checks if a comparison function can be optimized to use direct SQL operators
-func canOptimizeComparison(function *FunctionCallData) bool {
-	if len(function.Arguments) != 2 {
+// canOptimizeFunction checks if a function can be optimized to use direct SQL operators
+func canOptimizeFunction(function *FunctionCallData) bool {
+	_, found := functionToOperator[function.Name]
+	if !found {
 		return false
 	}
 
-	_, found := comparisonToOperator[function.Name]
-	if found {
-		// Both arguments must be primitive SQLite-compatible types
-		return isPrimitiveSQLiteType(function.Arguments[0]) && isPrimitiveSQLiteType(function.Arguments[1])
+	// Check argument count requirements
+	switch function.Name {
+	case "zetasqlite_and", "zetasqlite_or":
+		if len(function.Arguments) < 2 {
+			return false
+		}
+	default: // comparison operators
+		if len(function.Arguments) != 2 {
+			return false
+		}
 	}
 
-	return false
+	// All arguments must be primitive SQLite-compatible types or optimizable expressions
+	for _, arg := range function.Arguments {
+		if !isPrimitiveSQLiteType(arg) {
+			return false
+		}
+	}
+
+	return true
 }
 
-var comparisonToOperator = map[string]string{
+var functionToOperator = map[string]string{
+	// Comparison operators
 	"zetasqlite_equal":            "=",
 	"zetasqlite_not_equal":        "!=",
 	"zetasqlite_less":             "<",
 	"zetasqlite_greater":          ">",
 	"zetasqlite_less_or_equal":    "<=",
 	"zetasqlite_greater_or_equal": ">=",
+	// Logical operators
+	"zetasqlite_and": "AND",
+	"zetasqlite_or":  "OR",
 }
 
-// optimizeComparisonToSQL converts comparison functions to direct SQL operators
-func optimizeComparisonToSQL(functionName string, args []*SQLExpression) (*SQLExpression, error) {
-	if len(args) != 2 {
-		// Should not happen due to canOptimizeComparison check, but be safe
-		return nil, fmt.Errorf("expected 2 arguments, got %d", len(args))
-	}
-
-	operator, found := comparisonToOperator[functionName]
+// optimizeFunctionToSQL converts functions to direct SQL operators
+func optimizeFunctionToSQL(functionName string, args []*SQLExpression) (*SQLExpression, error) {
+	operator, found := functionToOperator[functionName]
 	if !found {
-		return nil, fmt.Errorf("unknown comparison operator: %s", functionName)
+		return nil, fmt.Errorf("unknown optimizable function: %s", functionName)
 	}
 
-	return NewBinaryExpression(args[0], operator, args[1]), nil
+	switch functionName {
+	case "zetasqlite_and", "zetasqlite_or":
+		if len(args) < 2 {
+			return nil, fmt.Errorf("%s expected at least 2 arguments, got %d", functionName, len(args))
+		}
+		// Chain multiple arguments with the operator
+		result := args[0]
+		for i := 1; i < len(args); i++ {
+			result = NewBinaryExpression(result, operator, args[i])
+		}
+		return result, nil
+
+	default: // comparison operators
+		if len(args) != 2 {
+			return nil, fmt.Errorf("%s expected 2 arguments, got %d", functionName, len(args))
+		}
+		return NewBinaryExpression(args[0], operator, args[1]), nil
+	}
 }
 
 // isPrimitiveSQLiteType checks if an expression represents a primitive type that SQLite can handle natively
+// or if it's an already-optimized expression that can be further optimized
 func isPrimitiveSQLiteType(expr ExpressionData) bool {
 	switch expr.Type {
 	case ExpressionTypeLiteral:
@@ -296,6 +327,13 @@ func isPrimitiveSQLiteType(expr ExpressionData) bool {
 			t.IsFloat() ||
 			t.IsDouble() ||
 			t.IsString()
+	case ExpressionTypeFunction:
+		// If this is an optimizable function, it can be treated as primitive for further optimization
+		if expr.Function != nil {
+			_, found := functionToOperator[expr.Function.Name]
+			return found && canOptimizeFunction(expr.Function)
+		}
+		return false
 	default:
 		return false
 	}

--- a/internal/types_data.go
+++ b/internal/types_data.go
@@ -113,6 +113,7 @@ type CastData struct {
 // ColumnRefData represents column reference data
 type ColumnRefData struct {
 	Column     *ast.Column `json:"column,omitempty"`
+	Type       types.Type  `json:"type,omitempty"`
 	TableAlias string      `json:"table_alias,omitempty"`
 	ColumnName string      `json:"column_name,omitempty"`
 	ColumnID   int         `json:"column_id,omitempty"`
@@ -127,6 +128,7 @@ func NewColumnExpressionData(column *ast.Column) ExpressionData {
 			ColumnName: column.Name(),
 			ColumnID:   column.ColumnID(),
 			TableName:  column.TableName(),
+			Type:       column.Type(),
 		},
 	}
 }


### PR DESCRIPTION
In some of our queries these comparison operators run tens of thousands, if not hundreds of thousands, of times. Calling the `go-zetasqlite` SQLite UDFs is extremely expensive when compared with comparison done within SQLite.

Here's a profile that showcases the somewhat disastrous query:

```(pprof) top20
Showing nodes accounting for 1008.54MB, 95.89% of 1051.76MB total
Showing top 20 nodes out of 40
      flat  flat%   sum%        cum   cum%
  417.51MB 39.70% 39.70%   420.01MB 39.93%  modernc.org/sqlite.functionArgs
  293.01MB 27.86% 67.56%   431.01MB 40.98%  github.com/goccy/go-zetasqlite/internal.convertArgs
  152.50MB 14.50% 82.06%  1012.73MB 96.29%  modernc.org/sqlite.funcTrampoline
     134MB 12.74% 94.80%   141.57MB 13.46%  github.com/goccy/go-zetasqlite/internal.DecodeValue
```

Here's a profile of the query with this optimization:
```
Showing nodes accounting for 56126.55kB, 82.58% of 67963.53kB total
Showing top 20 nodes out of 157
      flat  flat%   sum%        cum   cum%
11276.10kB 16.59% 16.59% 11276.10kB 16.59%  github.com/goccy/go-zetasqlite/internal.(*WindowFuncAggregatedStatus).RelevantValues
 5632.18kB  8.29% 24.88%  8704.47kB 12.81%  modernc.org/sqlite.functionArgs
 5130.01kB  7.55% 32.43%  5130.01kB  7.55%  runtime.allocm
 4608.33kB  6.78% 39.21%  4608.33kB  6.78%  encoding/base64.(*Encoding).DecodeString
 4608.16kB  6.78% 45.99%  9216.56kB 13.56%  github.com/goccy/go-zetasqlite/internal.convertArgs
```

The `modernc.org/sqlite` driver needs to create a new slice to hold the values from SQLite to pass to our UDF. It also needs to perform copies of the values from SQLite into the slice. We then do more-or-less the same operation inside of `convertArgs`, but this time we also `DecodeValue` / `EncodeValue` for the zetasqlite custom types.

I spent some time trying to optimize the encoding/decoding path, but in reality, the real issue was not with the value codec, but the fact that we're doing all this extra work when SQLite could just perform a simple `1 = 1` operation in C for us (as well as likely apply query-plan optimizations that it otherwise couldn't).
