### PR TITLE
fix: TRANSLATE function doesn't work with Unicode chars

### DIFF
--- a/internal/function_string.go
+++ b/internal/function_string.go
@@ -1217,17 +1217,19 @@ func TRANSLATE(expr, source, target Value) (Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		evaluatedByte := map[byte]struct{}{}
-		for i := 0; i < len(s); i++ {
-			if _, exists := evaluatedByte[s[i]]; exists {
-				return nil, fmt.Errorf("TRANSLATE: found duplicated source character: %c", s[i])
+		sourceRunes := []rune(s)
+		targetRunes := []rune(t)
+		evaluatedRune := map[rune]struct{}{}
+		for i, sourceRune := range sourceRunes {
+			if _, exists := evaluatedRune[sourceRune]; exists {
+				return nil, fmt.Errorf("TRANSLATE: found duplicated source character: %c", sourceRune)
 			}
-			if len(t) > i {
-				e = strings.ReplaceAll(e, string(s[i]), string(t[i]))
+			if len(targetRunes) > i {
+				e = strings.ReplaceAll(e, string(sourceRune), string(targetRunes[i]))
 			} else {
-				e = strings.ReplaceAll(e, string(s[i]), "")
+				e = strings.ReplaceAll(e, string(sourceRune), "")
 			}
-			evaluatedByte[s[i]] = struct{}{}
+			evaluatedRune[sourceRune] = struct{}{}
 		}
 		return StringValue(e), nil
 	case BytesValue:

--- a/query_test.go
+++ b/query_test.go
@@ -4897,6 +4897,26 @@ WITH example AS (
 			},
 		},
 		{
+			name: "translate unicode source and target",
+			query: `
+SELECT
+  TRANSLATE(
+    'ØøÐðĐđŁłıŊŋ',
+    CHR(216)||CHR(248)||CHR(208)||CHR(240)||CHR(272)||CHR(273)||CHR(321)||CHR(322)||CHR(305)||CHR(330)||CHR(331),
+    'OoDdDdLliNn'
+  ) AS got,
+  'OoDdDdLliNn' AS expected,
+  TRANSLATE(
+    'ØøÐðĐđŁłıŊŋ',
+    CHR(216)||CHR(248)||CHR(208)||CHR(240)||CHR(272)||CHR(273)||CHR(321)||CHR(322)||CHR(305)||CHR(330)||CHR(331),
+    'OoDdDdLliNn'
+  ) = 'OoDdDdLliNn' AS pass
+`,
+			expectedRows: [][]interface{}{
+				{"OoDdDdLliNn", "OoDdDdLliNn", true},
+			},
+		},
+		{
 			name:         "trim",
 			query:        `SELECT TRIM('   apple   '), TRIM('		apple	'), TRIM('***apple***', '*'), TRIM(NULL), TRIM('abc', NULL)`,
 			expectedRows: [][]interface{}{{"apple", "apple", "apple", nil, nil}},


### PR DESCRIPTION
Replaced byte-based approach with rune-based approach for `TRANSLATE` function.

You can run the test query exactly as is in a BQ Studio to verify it works the same way in real BQ.