### PR TITLE
fix: handle JSON null in JSON_EXTRACT_SCALAR and null elements in JSON string array functions

### DIFF
--- a/internal/function_json.go
+++ b/internal/function_json.go
@@ -99,6 +99,9 @@ func JSON_EXTRACT_SCALAR(v, path string) (Value, error) {
 		return nil, nil
 	}
 	value := values[0]
+	if !reflect.ValueOf(value).IsValid() {
+		return nil, nil
+	}
 	switch reflect.ValueOf(value).Type().Kind() {
 	case reflect.Map, reflect.Slice:
 		return nil, nil
@@ -166,6 +169,10 @@ func JSON_EXTRACT_STRING_ARRAY(v, path string) (Value, error) {
 	ret := &ArrayValue{}
 	for i := 0; i < rv.Len(); i++ {
 		elem := rv.Index(i).Interface()
+		if elem == nil {
+			ret.values = append(ret.values, nil)
+			continue
+		}
 		elemV := reflect.ValueOf(elem)
 		elemKind := elemV.Type().Kind()
 		if elemKind == reflect.Map || elemKind == reflect.Slice {
@@ -293,6 +300,10 @@ func JSON_VALUE_ARRAY(v, path string) (Value, error) {
 	ret := &ArrayValue{}
 	for i := 0; i < rv.Len(); i++ {
 		elem := rv.Index(i).Interface()
+		if elem == nil {
+			ret.values = append(ret.values, nil)
+			continue
+		}
 		elemV := reflect.ValueOf(elem)
 		elemKind := elemV.Type().Kind()
 		if elemKind == reflect.Map || elemKind == reflect.Slice {

--- a/query_test.go
+++ b/query_test.go
@@ -6263,6 +6263,14 @@ SELECT
 			expectedRows: [][]interface{}{{"world"}},
 		},
 		{
+			// Regression test: JSON_EXTRACT_SCALAR used to panic
+			// ("reflect: call of reflect.Value.Type on zero Value") when the
+			// extracted value was JSON null.
+			name:         "json_extract_scalar with null",
+			query:        `SELECT JSON_EXTRACT_SCALAR('{"a": null}', '$.a'), JSON_EXTRACT_SCALAR(JSON 'null'), JSON_EXTRACT_SCALAR(NULL), JSON_EXTRACT_SCALAR('{}', '$.does_not_exist')`,
+			expectedRows: [][]interface{}{{nil, nil, nil, nil}},
+		},
+		{
 			name:         "json_value with number",
 			query:        `SELECT JSON_VALUE(JSON '{ "name" : "Jakob", "age" : "6" }', '$.age')`,
 			expectedRows: [][]interface{}{{`6`}},
@@ -6429,6 +6437,13 @@ SELECT
 			expectedRows: [][]interface{}{{nil, nil, nil, nil, nil, nil, nil}},
 		},
 		{
+			// Regression test: a JSON null element used to panic instead of
+			// producing a NULL array element.
+			name:         "json_extract_string_array with null element",
+			query:        `SELECT JSON_EXTRACT_STRING_ARRAY('["a", null]', '$')`,
+			expectedRows: [][]interface{}{{[]interface{}{"a", nil}}},
+		},
+		{
 			name:         "json_extract_string_array with empty array",
 			query:        `SELECT JSON_EXTRACT_STRING_ARRAY('{"a":"foo","b":[]}','$.b')`,
 			expectedRows: [][]interface{}{{[]interface{}{}}},
@@ -6473,6 +6488,13 @@ SELECT
   JSON_VALUE_ARRAY('{"a":[10, {"b": 20}]','$.a'),
   JSON_VALUE_ARRAY(JSON 'null', '$')`,
 			expectedRows: [][]interface{}{{nil, nil, nil, nil, nil, nil, nil}},
+		},
+		{
+			// Regression test: a JSON null element used to panic instead of
+			// producing a NULL array element.
+			name:         "json_value_array with null element",
+			query:        `SELECT JSON_VALUE_ARRAY('["a", null]', '$')`,
+			expectedRows: [][]interface{}{{[]interface{}{"a", nil}}},
 		},
 		{
 			name:         "json_value_array with empty array",


### PR DESCRIPTION
## Summary

Part of [OBT-40536](https://linear.app/recidiviz/issue/OBT-40536/bigquery-emulator-hangs-when-json-extract-scalar-extracts-a-json-null).

`JSON_EXTRACT_SCALAR` panics (`reflect: call of reflect.Value.Type on zero Value`) when the extracted JSON value is `null`, and `JSON_EXTRACT_STRING_ARRAY`/`JSON_VALUE_ARRAY` panic the same way on a `null` array element. Live BigQuery returns SQL `NULL` in all of these cases.

Minimal repro:

```sql
SELECT JSON_EXTRACT_SCALAR('{"a": null}', '$.a')  -- live BQ: NULL; before this fix: panic
```

Downstream this is worse than a crash: in the bigquery-emulator the panic unwinds through modernc-sqlite's VM without releasing its internal locks, the server's recovery middleware keeps the process alive, and the wedged shared connection blocks every subsequent request — the emulator hangs forever (Recidiviz-internal OBT-40536).

Upstream fixed this bug class for the standard-mode functions in goccy/go-zetasqlite@8139de8 (goccy#121) — `JSON_VALUE` has an `IsValid()` guard — but missed legacy `JSON_EXTRACT_SCALAR` and the element loops in the two string-array functions.

## Changes

- `JSON_EXTRACT_SCALAR`: add the same `!reflect.ValueOf(value).IsValid()` guard `JSON_VALUE` has, returning SQL `NULL`.
- `JSON_EXTRACT_STRING_ARRAY` / `JSON_VALUE_ARRAY`: emit a `NULL` array element for a JSON `null` element instead of panicking (matching live BigQuery).
- Regression tests for all three in the `TestQuery` table.

## Testing

- New cases fail with the panic before the fix and pass after.
- `go test ./... -count=1` green (macOS arm64, TZ=UTC).
- Verified end-to-end against a locally built bigquery-emulator: the previously hanging query returns correct rows with NULLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)